### PR TITLE
fix error reporter is not a function

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -13,15 +13,10 @@ interface FileResult {
   warningsCount: number;
 }
 
-export default reporter;
-
-export const reporter = (files: VFile[], options?: object): string =>
+const reporter = (files: VFile[], options?: object): string =>
   reporterFileResult(files, options).text;
 
-export const reporterFileResult = (
-  files: VFile[],
-  _options?: object
-): FileResult => {
+const reporterFileResult = (files: VFile[], _options?: object): FileResult => {
   const fileResults = files
     .filter(x => x.messages.length > 0)
     .map(x => reportFile(x));
@@ -163,3 +158,5 @@ const warningColor = chalk.yellow;
 const errorColor = chalk.red;
 const lineNumberColor = (text: any): string => chalk.bgWhite(chalk.black(text));
 const sourceColor = chalk.magenta;
+
+module.exports = reporter;

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,5 +1,5 @@
 import vfile from 'vfile';
-import { reporter } from '../src';
+const reporter = require('../src');
 
 const file1 = vfile({
   path: 'src/test.md',


### PR DESCRIPTION
# Description

- fixes error reporter is not a function 


# Related Issues
- fixes #1 `Error "TypeError: reporter is not a function"`